### PR TITLE
[`Backend`] : Deprecate `tsukaeru` | Use caddy to handle file services

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -9,16 +9,15 @@
 
     # Django Rest API
     handle /api* {
-        reverse_proxy localhost:8000
+        reverse_proxy localhost:8000 {
+            @sendfile header X-Sendfile *
+            handle_response @sendfile {
+                rewrite {http.reverse_proxy.header.X-Sendfile}
+                encode zstd gzip
+                file_server
+            }
+        }
     }
-
-    # Django FAQ
-    # This will work if we add the correct path in Django Admin
-    # Think of it as 2 way verification
-    handle /faq* {
-        reverse_proxy localhost:8000
-    }
-
 
     # Svelte app working
     handle_path /anime* {

--- a/backend/django_core/apps/user/views.py
+++ b/backend/django_core/apps/user/views.py
@@ -1,8 +1,8 @@
 from collections.abc import Generator
 import hashlib
 from typing import IO
-from core.utility import sendfile, sendbytes
 
+from core.utility import sendbytes, sendfile
 from yarl import URL
 
 from django.conf import settings

--- a/backend/django_core/core/utility.py
+++ b/backend/django_core/core/utility.py
@@ -1,0 +1,69 @@
+from collections.abc import Generator
+import mimetypes
+from django.http import HttpResponse, StreamingHttpResponse
+from io import BufferedReader, BytesIO
+from pathlib import Path
+from django.conf import settings
+from typing import IO, Optional
+
+CHUNK_SIZE = 512  # 512 bytes
+
+
+def read_files_in_chunks(
+    file_object: IO[bytes],
+    chunk_size: int = CHUNK_SIZE,
+) -> Generator[bytes, None, None]:
+    """
+    Lazy function to read a file piece by piece.
+    """
+    while True:
+        data = file_object.read(chunk_size)
+        if not data:
+            break
+        yield data
+
+    file_object.close()
+
+
+def sendfile(
+    file_path: str | Path,
+    content_type: Optional[str],
+) -> HttpResponse | StreamingHttpResponse:
+    file_location = f"{settings.MEDIA_ROOT}/{file_path}"
+
+    if not settings.DEBUG:
+        response = HttpResponse()
+        response["X-Sendfile"] = file_location
+        del response["content-type"]
+        return response
+
+    else:
+        file_iterator = read_files_in_chunks(file_location)
+        response = StreamingHttpResponse(
+            streaming_content=file_iterator,
+        )
+        response["content-type"] = (
+            content_type
+            if content_type
+            else str(
+                mimetypes.MimeTypes().guess_type(
+                    url=file_location,
+                )[0]
+            )
+        )
+        return response
+
+
+def sendbytes(
+    file_blob: BufferedReader,
+    content_type: str,
+) -> HttpResponse:
+    if not settings.DEBUG:
+        response = HttpResponse()
+        response["X-Sendfile"] = BytesIO(file_blob)
+        del response["content-type"]
+        return response
+
+    else:
+        data = BytesIO(file_blob)
+        return HttpResponse(data, content_type=content_type)

--- a/backend/django_core/core/utility.py
+++ b/backend/django_core/core/utility.py
@@ -1,10 +1,11 @@
 from collections.abc import Generator
-import mimetypes
-from django.http import HttpResponse, StreamingHttpResponse
 from io import BufferedReader, BytesIO
+import mimetypes
 from pathlib import Path
-from django.conf import settings
 from typing import IO, Optional
+
+from django.conf import settings
+from django.http import HttpResponse, StreamingHttpResponse
 
 CHUNK_SIZE = 512  # 512 bytes
 
@@ -27,7 +28,7 @@ def read_files_in_chunks(
 
 def sendfile(
     file_path: str | Path,
-    content_type: Optional[str],
+    content_type: str | None,
 ) -> HttpResponse | StreamingHttpResponse:
     file_location = f"{settings.MEDIA_ROOT}/{file_path}"
 

--- a/backend/django_core/core/utility.py
+++ b/backend/django_core/core/utility.py
@@ -2,7 +2,7 @@ from collections.abc import Generator
 from io import BufferedReader, BytesIO
 import mimetypes
 from pathlib import Path
-from typing import IO, Optional
+from typing import IO
 
 from django.conf import settings
 from django.http import HttpResponse, StreamingHttpResponse


### PR DESCRIPTION
Put an end to microservice madness 